### PR TITLE
[fix] Remove unusable FolderID from RoutineUpdateInput

### DIFF
--- a/routines_test.go
+++ b/routines_test.go
@@ -2,6 +2,10 @@ package hevy_test
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,4 +91,31 @@ func TestRoutinesUpdate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "80155158-4a80-478d-bdeb-1070b57e5c7e", routine.ID)
 	require.Len(t, routine.Exercises, 1)
+}
+
+// TestRoutinesUpdateNeverSendsFolderID locks in the request shape sent by
+// Update: the real API rejects PUT /v1/routines/{id} requests that include
+// a folder_id key at all (400 Unrecognized key(s)), even when the value is
+// null, so RoutineUpdateInput must never have a FolderID field to send.
+func TestRoutinesUpdateNeverSendsFolderID(t *testing.T) {
+	var captured map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var decoded map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(body, &decoded))
+		require.NoError(t, json.Unmarshal(decoded["routine"], &captured))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"routine":[{"id":"r1","title":"Test"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := hevy.New("test-key", hevy.WithBaseURL(srv.URL))
+
+	_, err := client.Routines.Update(context.Background(), "r1", hevy.RoutineUpdateInput{
+		Title: "Test",
+	})
+	require.NoError(t, err)
+
+	_, hasFolderID := captured["folder_id"]
+	assert.False(t, hasFolderID, "update request body must never include folder_id: the API rejects it with a 400")
 }

--- a/types.go
+++ b/types.go
@@ -354,10 +354,12 @@ type RoutineInput struct {
 }
 
 // RoutineUpdateInput is the payload for PUT /v1/routines/{routineId}.
-// Notes is optional (unlike create).
+// Notes is optional (unlike create). The API does not support moving a
+// routine to a different folder via update; there is no FolderID field
+// here because the API rejects the folder_id key entirely on this
+// endpoint (400 Unrecognized key(s), even when set to null).
 type RoutineUpdateInput struct {
 	Title     string                 `json:"title"`
-	FolderID  *float64               `json:"folder_id,omitempty"`
 	Notes     *string                `json:"notes,omitempty"`
 	Exercises []RoutineExerciseInput `json:"exercises"`
 }


### PR DESCRIPTION
## Summary
- Stacked on #30 (needs that branch's Update fix to land first; this PR's diff is just the one commit on top).
- `PUT /v1/routines/{id}` rejects any request body containing a `folder_id` key with a 400 (`"Unrecognized key(s) in object: 'folder_id'"`) — confirmed live against the API with a real value, `null`, and the `folderId` camelCase alias, all three rejected. Omitting the key entirely succeeds and preserves the routine's existing folder.
- `RoutineUpdateInput.FolderID` could therefore never be set successfully; routine folder reassignment is only possible through `Create`, not `Update`.
- Removed the field so the type doesn't advertise a capability the API doesn't support, and added a test asserting `Update` never sends a `folder_id` key in the request body.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` passes, including new `TestRoutinesUpdateNeverSendsFolderID`
- [x] Verified live against the Hevy API: PUT with `folder_id` (value, null, or `folderId`) → 400; PUT without it → 200 with folder preserved